### PR TITLE
✨ feat: automatic version checking and binary updates

### DIFF
--- a/claude-code-extension/src/lib.rs
+++ b/claude-code-extension/src/lib.rs
@@ -250,16 +250,6 @@ fn download_server_binary() -> Result<String, String> {
         }
     }
 
-    // Clean up legacy version file (from old code that used separate version tracking)
-    const LEGACY_VERSION_FILE: &str = ".claude-code-server-version";
-    if std::path::Path::new(LEGACY_VERSION_FILE).exists() {
-        if let Err(e) = std::fs::remove_file(LEGACY_VERSION_FILE) {
-            eprintln!("⚠️ [WARNING] Failed to remove legacy version file: {}", e);
-        } else {
-            eprintln!("🗑️ [INFO] Removed legacy version file: {}", LEGACY_VERSION_FILE);
-        }
-    }
-
     // Log all available assets for debugging
     eprintln!("🔍 [DEBUG] Available assets:");
     for asset in &release.assets {

--- a/claude-code-extension/src/lib.rs
+++ b/claude-code-extension/src/lib.rs
@@ -230,7 +230,7 @@ fn download_server_binary() -> Result<String, String> {
         return Ok(versioned_binary_name);
     }
 
-    // Check for and clean up old versions
+    // Check for and clean up old versions (with version suffix)
     if let Some(old_binary) = find_existing_binary(&binary_prefix) {
         eprintln!("🔄 [INFO] Found old version: {}, will update to {}", old_binary, release.version);
         if let Err(e) = std::fs::remove_file(&old_binary) {
@@ -238,8 +238,26 @@ fn download_server_binary() -> Result<String, String> {
         } else {
             eprintln!("🗑️ [INFO] Removed old binary: {}", old_binary);
         }
-    } else {
-        eprintln!("📥 [INFO] No existing binary found, will download");
+    }
+
+    // Also clean up legacy non-versioned binary (from old code before version embedding)
+    if std::path::Path::new(&binary_prefix).exists() {
+        eprintln!("🔄 [INFO] Found legacy non-versioned binary: {}", binary_prefix);
+        if let Err(e) = std::fs::remove_file(&binary_prefix) {
+            eprintln!("⚠️ [WARNING] Failed to remove legacy binary {}: {}", binary_prefix, e);
+        } else {
+            eprintln!("🗑️ [INFO] Removed legacy binary: {}", binary_prefix);
+        }
+    }
+
+    // Clean up legacy version file (from old code that used separate version tracking)
+    const LEGACY_VERSION_FILE: &str = ".claude-code-server-version";
+    if std::path::Path::new(LEGACY_VERSION_FILE).exists() {
+        if let Err(e) = std::fs::remove_file(LEGACY_VERSION_FILE) {
+            eprintln!("⚠️ [WARNING] Failed to remove legacy version file: {}", e);
+        } else {
+            eprintln!("🗑️ [INFO] Removed legacy version file: {}", LEGACY_VERSION_FILE);
+        }
     }
 
     // Log all available assets for debugging


### PR DESCRIPTION
## Summary

- Add automatic version checking for claude-code-server binary
- Embed version in binary filename (e.g., `claude-code-server-macos-aarch64-v0.1.0`)
- Automatically detect and update to newer versions from GitHub releases
- Clean up old/legacy binaries when updating

## Changes

- Rename `get_platform_binary_name()` to `get_platform_binary_prefix()` to reflect new naming
- Add `find_existing_binaries()` to detect old versioned and legacy binaries
- Download new versions with embedded version suffix
- Remove old binaries when a new version is downloaded

## Test plan

- [ ] Build extension and install in Zed
- [ ] Open a project to trigger server download
- [ ] Verify binary is downloaded with version suffix (e.g., `-v0.1.0`)
- [ ] Create a new GitHub release with higher version
- [ ] Restart Zed and verify old binary is replaced with new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)